### PR TITLE
Add ApplicationEventListener to track startup app running process

### DIFF
--- a/modules/springboot/basic/startup/pom.xml
+++ b/modules/springboot/basic/startup/pom.xml
@@ -8,7 +8,7 @@
         <artifactId>basic</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <artifactId>startup-listeners</artifactId>
+    <artifactId>startup</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
     <properties>

--- a/modules/springboot/basic/startup/src/main/java/startup/StartupEventListener.java
+++ b/modules/springboot/basic/startup/src/main/java/startup/StartupEventListener.java
@@ -1,0 +1,43 @@
+package startup;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.*;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+/**
+ * 统一监听 Spring Boot 启动各阶段事件并记录时间戳
+ */
+@Component  // 注册为 Spring Bean，自动被 SpringApplication.run() 扫描
+public class StartupEventListener implements ApplicationListener<ApplicationEvent> {
+
+    // 使用 SLF4J 的 Logger 而非 java.util.logging.Logger
+    private static final Logger log = LoggerFactory.getLogger(StartupEventListener.class);
+
+    @Override
+    public void onApplicationEvent(ApplicationEvent event) {
+        String timestamp = Instant.now().toString();  // 获取当前 UTC 时间戳
+
+        // 根据事件类型记录对应日志，统一使用 {} 占位符传入 timestamp
+        if (event instanceof ApplicationStartingEvent) {
+            log.info("[StartupEvent] ApplicationStartingEvent at {}", timestamp);
+        } else if (event instanceof ApplicationEnvironmentPreparedEvent) {
+            log.info("[StartupEvent] ApplicationEnvironmentPreparedEvent at {}", timestamp);
+        } else if (event instanceof ApplicationContextInitializedEvent) {
+            log.info("[StartupEvent] ApplicationContextInitializedEvent at {}", timestamp);
+        } else if (event instanceof ApplicationPreparedEvent) {
+            log.info("[StartupEvent] ApplicationPreparedEvent at {}", timestamp);
+        } else if (event instanceof ApplicationStartedEvent) {
+            log.info("[StartupEvent] ApplicationStartedEvent at {}", timestamp);
+        } else if (event instanceof ApplicationReadyEvent) {
+            log.info("[StartupEvent] ApplicationReadyEvent at {}", timestamp);
+        } else if (event instanceof ApplicationFailedEvent) {
+            log.error("[StartupEvent] ApplicationFailedEvent at {}", timestamp);
+        }
+    }
+}
+

--- a/modules/springboot/basic/startup/src/main/java/startup/StartupListenersApplication.java
+++ b/modules/springboot/basic/startup/src/main/java/startup/StartupListenersApplication.java
@@ -1,0 +1,21 @@
+package startup;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+    /**
+     * 应用入口类
+     * 通过add listener注册启动时间监听器以模拟各阶段日志
+     */
+    @SpringBootApplication
+    public class StartupListenersApplication {
+        public static void main(String[] args){
+            // SpringApplication的构造函数接收一个或者多个source class,用于标识应用的猪配置入口。该类通常被标注为@SpringBootApplication。
+            // 1. SpringApplication会基于此类加载主配置(将该类以及其依赖的自动配置类注册到容器）
+            // 2. 确定组件扫描基础包路径，默认扫描该类所在包以及子包
+            // 3. 作为错误报告与上下文环境初始化的参考点
+            SpringApplication app = new SpringApplication(StartupListenersApplication.class);
+            app.addListeners(new StartupEventListener());
+            app.run(args);
+        }
+    }

--- a/modules/springboot/basic/startup/src/main/resources/application.properties
+++ b/modules/springboot/basic/startup/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=8081
+spring.main.banner-mode = off


### PR DESCRIPTION
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/e82612c1-d174-4dad-92f7-050a904da2ce" />

### PR 概述 (Summary)

* 本次 PR 为实现“捕获并打印 Spring Boot 启动流程关键事件”需求，新增了 `StartupEventListener`，并在 `StartupListenersApplication` 中注册该监听器。
* 实现了对 `ApplicationEnvironmentPreparedEvent`、`ApplicationPreparedEvent`、`ContextRefreshedEvent`、`ApplicationStartedEvent`、`ApplicationReadyEvent`、`ApplicationFailedEvent` 的日志打印。

### 实现步骤 (Implementation)

* **新增监听器**：`StartupEventListener` 实现 `ApplicationListener<ApplicationEvent>`，在 `onApplicationEvent` 中使用 SLF4J `Logger` 输出事件类型及 `Instant.now()` 时间戳。
* **修改入口类**：`StartupListenersApplication` 中用 `new SpringApplication(...)`，调用 `addListeners(new StartupEventListener())` 注册监听器，并通过 `@SpringBootApplication(exclude = DataSourceAutoConfiguration.class)` 排除默认的 JDBC 自动装配。
* **Maven 插件配置**：在 `startup/pom.xml` 中添加 `spring-boot-maven-plugin` 插件声明，并引入 `spring-boot-starter-web` 与 `spring-boot-starter-actuator` 依赖，确保 `mvn spring-boot:run -pl startup` 可执行。

### 遇到的问题与调试 (Bugs & Debugging)

* **目录与包不匹配**

  * 问题：源码直接放于 `src/main/java` 根目录，无 `package` 或目录层次，Maven 编译不会扫描。
  * 调试：`tree -I target` 验证源码路径，发现应创建 `com/backend/basic/startup` 子目录或使用 `scanBasePackages`。
* **No plugin found for prefix 'spring-boot'**

  * 问题：父模块 `packaging=pom` 未声明插件，子模块继承不到 `spring-boot-maven-plugin`。
  * 调试：检查 `startup/pom.xml`，在 `<build><plugins>` 中添加插件声明，解决前缀解析失败。
* **Unable to find a suitable main class**

  * 问题：插件找不到含 `public static void main` 的类；源码未按 Maven 约定放置或包声明不对。
  * 调试：确认入口类存在并在插件配置中可显式指定 `<configuration><mainClass>`，或修正源码目录与 `package`。
* **默认包扫描过度**

  * 问题：类在 default package，`@ComponentScan` 扫描整个类路径，尝试加载 `DataSourceAutoConfiguration$EmbeddedDatabaseConfiguration`，缺少 `DataAccessException` 报错。
  * 调试：在 `--debug` 模式下查看 `ConditionEvaluationReport`，定位缺失类；通过排除自动装配或在正确包下重构代码解决。
* **缺少 ContextRefreshedEvent**

  * 问题：初版监听器漏写对 `ContextRefreshedEvent` 的判断。
  * 调试：IDE 断点跟踪 `ApplicationContext.refresh()` 流程，补充对应 `instanceof ContextRefreshedEvent` 分支。
* **Maven 多模块依赖管理错误**

  * 问题：将普通 Starter（如 `spring-boot-starter-web`）误用 `type="pom" scope="import"` 导入，导致子模块缺少版本信息报错。
  * 调试：阅读父 POM `dependencyManagement` 配置，调整仅 `import` 官方 BOM `spring-boot-dependencies`，子模块依赖无需指定 `<version>`。

### Maven 配置及多模块问题 (Maven & Multi-Module)

* 父 POM 需通过 `<dependencyManagement>` 导入官方 BOM：

  ```xml
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-dependencies</artifactId>
        <version>3.4.5</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>
  ```
* 子模块 POM 正确继承父 PLC 坐标，声明插件与依赖：

  ```xml
  <parent>…</parent>
  <dependencies>…</dependencies>
  <build>
    <plugins>
      <plugin>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
      </plugin>
    </plugins>
  </build>
  ```
* 使用 `mvn spring-boot:run -pl startup` 或在父目录 `mvn -pl startup spring-boot:run` 运行子模块。

#### 1. `record` 与 POJO 权衡

* POJO 需手写构造器和 getter/setter，灵活适配 ORM；Record（Java 16+）自动生成方法，支持不可变数据载体，适合轻量场景；DTO（Data Transfer Object）适合接口层校验或去敏。
* `record User(Long id,String name){}` vs POJO vs 链式 DTO 示例见上。
* **风险**：Record 默认无参构造器，对 Hibernate 不友好；POJO 样板多；DTO 可定制校验。

#### 2. 外部化配置 (Externalized Configuration)

* 将运行时参数（URL、开关、凭证）从代码分离到 `application.properties`/`.yml`、环境变量或 `spring.config.import` 引入，实现不同 Profile 切换。

##### 3. BOM 与 `pom.xml` 配置

* 官方 BOM `spring-boot-dependencies` 管理 Starter 版本，普通 Starter 不应 `import`；`type="pom" scope="import"` 仅用于 BOM；

#### 4. BOM 及依赖调用顺序

* Maven 版本合并遵循：父 BOM → 当前 BOM import → 当前 `dependencyManagement` 显式 → `dependencies`。

#### 5. Maven 坐标系 (GAV)

* `groupId` 反向域名分组；`artifactId` 模块唯一标识；子模块通过 `<parent>` 继承 groupId/version；

#### 6. Maven 聚合包 (Aggregator POM)

* `<packaging>pom</packaging>` 组织多个子模块，统一管理 `<dependencyManagement>` 与 `<pluginManagement>`，提高构建效率。

#### 7. `SpringApplication.run()` 触发事件

* 依次发布：`ApplicationStartingEvent` → `ApplicationEnvironmentPreparedEvent` → `ApplicationContextInitializedEvent` → `ApplicationPreparedEvent` → `ApplicationStartedEvent` → `ApplicationReadyEvent` → `ApplicationFailedEvent`；可插入自定义逻辑。

#### 8. 日志记录 (Logging)

* 使用 SLF4J (`LoggerFactory.getLogger(...)`) 实现参数化日志 (`{}` 占位符)；支持多级别（TRACE/DEBUG/INFO/WARN/ERROR）和异步 Appender。

#### 9. Logger 优势

* 分级管理、可配置输出、参数化避免拼接开销、与 Spring Boot/Micrometer 集成、支持文件/远程目标。

#### 10. 子模块 `application.properties` 继承

* 方案：`spring.config.import=classpath:config/application-common.properties` 或提取公共 `common-config` 模块并依赖，实现配置复用与覆盖。


### 验证结果（Verification）

* 本地执行 `mvn spring-boot:run -pl startup`，在控制台依次打印：

  ```
  [StartupEvent] ApplicationEnvironmentPreparedEvent at …  
  [StartupEvent] ContextRefreshedEvent at …  
  [StartupEvent] ApplicationPreparedEvent at …  
  [StartupEvent] ApplicationStartedEvent at …  
  [StartupEvent] ApplicationReadyEvent at …  
  ```
* 启用 `--debug` 后可在 `/actuator/conditions` 查看自动装配加载顺序，与 Banner 打印时机符合预期。
* 日志顺序与 IDE 断点流程对比一致，满足验收标准。

### 备注（Notes）

* 下阶段可将该监听器封装为 Spring Boot Starter，通过 `spring.factories` 自动注册；
* 可集成 Micrometer 统计各阶段耗时并上报至 Prometheus。
